### PR TITLE
[breaking] feat: add minijinja

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,7 +20,8 @@
                 }
             },
             "args": [
-                "tests/test.yaml",
+                "workflow",
+                "tests/workflow.yaml",
                 "--variables",
                 "FOO=BAR"
             ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,11 @@
                 "workflow",
                 "tests/workflow.yaml",
                 "--variables",
-                "FOO=BAR"
+                "FOO=BAR",
+                "-f",
+                "tests/context.yaml",
+                "-f",
+                "tests/context2.yaml"
             ],
             "cwd": "${workspaceFolder}"
         },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,6 +465,7 @@ dependencies = [
  "httpmock",
  "jsonpath",
  "log",
+ "minijinja",
  "reqwest",
  "schemars",
  "serde",
@@ -1392,6 +1393,15 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minijinja"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57be929672ea2de446d39b3626c1cd1e55bd1db40f90ebee28d242a3d6baa65f"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "minimad"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ simplelog = "0.12"
 strum = { version = "0.26", features = ["derive"] }
 termimad = "0.29"
 tokio = { version = "1", features = ["full"] }
+minijinja = "1"
 
 [dev-dependencies]
 httpmock = "0.6"

--- a/src/climan.rs
+++ b/src/climan.rs
@@ -37,8 +37,12 @@ mod tests {
         let result = workflow
             .execute(&client, HashMap::new(), None, &|_, _| (), &|_, _, _| ())
             .await;
-
-        assert!(result.is_ok());
+        match result {
+            Ok(_) => (),
+            Err(error) => {
+                panic!("test workflow failed: {error:?}");
+            }
+        }
         Ok(())
     }
 }

--- a/src/climan.rs
+++ b/src/climan.rs
@@ -35,7 +35,7 @@ mod tests {
         let client = reqwest::Client::new();
         let workflow: Workflow = serde_yaml::from_str(&test_spec)?;
         let result = workflow
-            .execute(&client, HashMap::new(), &|_, _| (), &|_, _, _| ())
+            .execute(&client, HashMap::new(), None, &|_, _| (), &|_, _, _| ())
             .await;
 
         assert!(result.is_ok());

--- a/src/climan/workflow.rs
+++ b/src/climan/workflow.rs
@@ -49,7 +49,7 @@ impl Workflow {
 
         let mut additional_variables: HashMap<String, Option<String>> = HashMap::new();
 
-        for file in files.unwrap_or(vec![]) {
+        for file in files.unwrap_or_default() {
             let filename = file.display().to_string();
             debug!("loading context from file: {}", filename);
             let file_variables: HashMap<String, Option<String>> = match tokio::fs::read(file).await

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,9 @@ use log::{error, LevelFilter};
 use schemars::schema_for;
 
 use std::borrow::Borrow;
+use std::path::PathBuf;
 use std::{collections::HashMap, env, fs::File, process::ExitCode};
-use termimad::minimad::{TextTemplate};
+use termimad::minimad::TextTemplate;
 use termimad::MadSkin;
 
 mod climan;
@@ -176,6 +177,10 @@ enum Command {
         #[arg(short, long)]
         variables: Option<Vec<String>>,
 
+        /// yaml files with additional variables
+        #[arg(short, long)]
+        files: Option<Vec<PathBuf>>,
+
         /// Include environment variables as initial variables
         #[arg(short, long)]
         env: bool,
@@ -267,6 +272,7 @@ async fn main() -> anyhow::Result<ExitCode> {
         Command::Workflow {
             path,
             variables,
+            files,
             env,
         } => {
             let content = std::fs::read_to_string(path)?;
@@ -281,7 +287,13 @@ async fn main() -> anyhow::Result<ExitCode> {
 
             skin.print_expander(workflow_expander);
             let result = workflow
-                .execute(&client, all_vars, &skinned_on_request, &skinned_on_response)
+                .execute(
+                    &client,
+                    all_vars,
+                    files,
+                    &skinned_on_request,
+                    &skinned_on_response,
+                )
                 .await;
 
             if result.is_err() {

--- a/tests/context.yaml
+++ b/tests/context.yaml
@@ -1,0 +1,1 @@
+some_value: "some value"

--- a/tests/context2.yaml
+++ b/tests/context2.yaml
@@ -1,0 +1,1 @@
+some_other_value: "some other value"

--- a/tests/echo.json
+++ b/tests/echo.json
@@ -1,25 +1,21 @@
 {
-    "json": {
-        "strValue": "this is a string, $FOO",
-        "numberValue": 37.4,
-        "arrayValue": [
-            1,
-            2,
-            3
-        ],
-        "objectValue": {
-            "field1": 1,
-            "field2": "2"
-        },
-        "objectArrayValue": [
-            {
-                "value": 1,
-                "other": "bla"
-            },
-            {
-                "value": 2,
-                "other": "blabla"
-            }
-        ]
-    }
+  "json": {
+    "strValue": "this is a string, BAR",
+    "numberValue": 37.4,
+    "arrayValue": [1, 2, 3],
+    "objectValue": {
+      "field1": 1,
+      "field2": "2"
+    },
+    "objectArrayValue": [
+      {
+        "value": 1,
+        "other": "bla"
+      },
+      {
+        "value": 2,
+        "other": "blabla"
+      }
+    ]
+  }
 }

--- a/tests/workflow.yaml
+++ b/tests/workflow.yaml
@@ -1,4 +1,5 @@
 name: TestWorkflow
+context: "tests/context.yaml"
 requests:
   - name: echo
     uri: https://postman-echo.com/post
@@ -17,7 +18,7 @@ requests:
     body:
       content: |
         {
-          "strValue": "this is a string, $FOO",
+          "strValue": "this is a string, {{ FOO }}",
           "numberValue": 37.4,
           "arrayValue": [1,2,3],
           "objectValue": {
@@ -39,4 +40,4 @@ requests:
     uri: https://postman-echo.com/get
     method: GET
     queryParams:
-      foo: $theString
+      foo: "{{ theString }}"

--- a/tests/workflow.yaml
+++ b/tests/workflow.yaml
@@ -1,5 +1,4 @@
 name: TestWorkflow
-context: "tests/context.yaml"
 requests:
   - name: echo
     uri: https://postman-echo.com/post
@@ -36,6 +35,7 @@ requests:
       theArray: $.json.arrayValue
       theObject: $.json.objectValue.field1
       theArrayObject: "$.json.objectArrayValue[1].value"
+    assertion: status == 200 and theString == "this is a string, BAR"
   - name: echo2
     uri: https://postman-echo.com/get
     method: GET


### PR DESCRIPTION
this adds https://github.com/mitsuhiko/minijinja to allow more powerful templating for example in the request body.
this is a breaking change as the templating escape changes from prefix `$` to a wrapper `{{ }}`.

+ also adds an assertion option for a request based on the jinja language

## minor changes
+ load additional context from files
+ stop workflow after failed request
+ accidental formatting of `request.rs`